### PR TITLE
androidEphemeralBrowsingEnabled option: updated androidx.browser

### DIFF
--- a/packages/react-native-app-auth/android/build.gradle
+++ b/packages/react-native-app-auth/android/build.gradle
@@ -62,5 +62,5 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation 'net.openid:appauth:0.11.1'
-    implementation 'androidx.browser:browser:1.4.0'
+    implementation 'androidx.browser:browser:1.9.0-alpha04'
 }


### PR DESCRIPTION
## Description

bump androidx.browser:browser version to 1.9.0-alpha04 to allow the [ENABLE_EPHEMERAL_BROWSING](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent#EXTRA_ENABLE_EPHEMERAL_BROWSING()) feature.